### PR TITLE
Feature/#13 visualtagview modification

### DIFF
--- a/Spacer/Spacer.xcodeproj/project.pbxproj
+++ b/Spacer/Spacer.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		D486C47529012EB400D6B0A0 /* CancelButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D486C47429012EB400D6B0A0 /* CancelButton.swift */; };
 		D486C47929013DBB00D6B0A0 /* NextButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D486C47829013DBB00D6B0A0 /* NextButton.swift */; };
 		D486C47B29013FC200D6B0A0 /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D486C47A29013FC200D6B0A0 /* BackButton.swift */; };
+		D486C48B290280C200D6B0A0 /* GridCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D486C489290280C200D6B0A0 /* GridCollectionViewCell.swift */; };
 		D4A3729B29011A79007A5297 /* CustomCalenderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A3729329011A79007A5297 /* CustomCalenderCell.swift */; };
 		D4A3729C29011A79007A5297 /* VisualTagCalendarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A3729429011A79007A5297 /* VisualTagCalendarViewController.swift */; };
 		D4A3729D29011A79007A5297 /* VisualTagMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A3729629011A79007A5297 /* VisualTagMapViewController.swift */; };
@@ -77,6 +78,7 @@
 		D486C47429012EB400D6B0A0 /* CancelButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelButton.swift; sourceTree = "<group>"; };
 		D486C47829013DBB00D6B0A0 /* NextButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextButton.swift; sourceTree = "<group>"; };
 		D486C47A29013FC200D6B0A0 /* BackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButton.swift; sourceTree = "<group>"; };
+		D486C489290280C200D6B0A0 /* GridCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GridCollectionViewCell.swift; sourceTree = "<group>"; };
 		D4A3729329011A79007A5297 /* CustomCalenderCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomCalenderCell.swift; sourceTree = "<group>"; };
 		D4A3729429011A79007A5297 /* VisualTagCalendarViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VisualTagCalendarViewController.swift; sourceTree = "<group>"; };
 		D4A3729629011A79007A5297 /* VisualTagMapViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VisualTagMapViewController.swift; sourceTree = "<group>"; };
@@ -242,6 +244,14 @@
 			path = FavoriteView;
 			sourceTree = "<group>";
 		};
+		D486C4912905A89F00D6B0A0 /* GridCell */ = {
+			isa = PBXGroup;
+			children = (
+				D486C489290280C200D6B0A0 /* GridCollectionViewCell.swift */,
+			);
+			path = GridCell;
+			sourceTree = "<group>";
+		};
 		D4A3729029011A79007A5297 /* VisualTagView */ = {
 			isa = PBXGroup;
 			children = (
@@ -250,6 +260,7 @@
 				D4A3729729011A79007A5297 /* PeopleTarget */,
 				D4A3729929011A79007A5297 /* PeopleRange */,
 				BFD1381429014DAF004E6726 /* Buttons */,
+				D486C4912905A89F00D6B0A0 /* GridCell */,
 			);
 			path = VisualTagView;
 			sourceTree = "<group>";
@@ -419,6 +430,7 @@
 				D4A3729B29011A79007A5297 /* CustomCalenderCell.swift in Sources */,
 				BF5F8AC128FEC91300CF9E3A /* ResultCollectionViewCell.swift in Sources */,
 				BF5F8ABF28FEC8E700CF9E3A /* CustomButtonView.swift in Sources */,
+				D486C48B290280C200D6B0A0 /* GridCollectionViewCell.swift in Sources */,
 				BF5F8AAE28FE736D00CF9E3A /* CafeInfo.swift in Sources */,
 				D4E950BC28EF48CA0066B711 /* AppDelegate.swift in Sources */,
 				D454704428FD1A9F00CFDB25 /* CustomSegmentControl.swift in Sources */,

--- a/Spacer/Spacer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Spacer/Spacer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,7 +3,7 @@
     {
       "identity" : "fscalendar",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/WenchaoD/FSCalendar",
+      "location" : "https://github.com/WenchaoD/FSCalendar.git",
       "state" : {
         "revision" : "0fbdec5172fccb90f707472eeaea4ffe095278f6",
         "version" : "2.8.4"

--- a/Spacer/Spacer/Cores/SceneDelegate.swift
+++ b/Spacer/Spacer/Cores/SceneDelegate.swift
@@ -20,7 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(frame: windowScene.coordinateSpace.bounds)
         window?.windowScene = windowScene
-        window?.rootViewController = MainTabBarViewController()
+        window?.rootViewController = RequestViewController()
         window?.makeKeyAndVisible()
     }
 

--- a/Spacer/Spacer/Cores/SceneDelegate.swift
+++ b/Spacer/Spacer/Cores/SceneDelegate.swift
@@ -20,7 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(frame: windowScene.coordinateSpace.bounds)
         window?.windowScene = windowScene
-        window?.rootViewController = RequestViewController()
+        window?.rootViewController = MainTabBarViewController()
         window?.makeKeyAndVisible()
     }
 

--- a/Spacer/Spacer/Views/VisualTagView/GridCell/GridCollectionViewCell.swift
+++ b/Spacer/Spacer/Views/VisualTagView/GridCell/GridCollectionViewCell.swift
@@ -40,11 +40,6 @@ class GridCollectionViewCell: UICollectionViewCell {
         }
     }
     
-    //StoryBoard를 사용했을 때 Nib을 활용하여 Cell 구성
-    override func awakeFromNib() {
-        super.awakeFromNib()
-    }
-    
     required init(coder aDecoder: NSCoder){
         fatalError("init(coder: ) has not been implemented")
     }

--- a/Spacer/Spacer/Views/VisualTagView/GridCell/GridCollectionViewCell.swift
+++ b/Spacer/Spacer/Views/VisualTagView/GridCell/GridCollectionViewCell.swift
@@ -1,0 +1,65 @@
+//
+//  GridCollectionViewCell.swift
+//  Spacer
+//
+//  Created by Hyung Seo Han on 2022/10/21.
+//
+
+import UIKit
+
+class GridCollectionViewCell: UICollectionViewCell {
+    //cell의 고유한 ID값 지정
+    static let identifier = "GridViewCell"
+    
+    lazy var label: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(for: .header6)
+        label.textColor = .mainPurple2
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    override init(frame: CGRect){
+        super.init(frame: .zero)
+        contentView.addSubview(label)
+        setConstraints()
+    }
+    
+    //isSelected 변수 override
+    override var isSelected: Bool {
+        didSet{
+            if isSelected{
+                self.backgroundColor = UIColor.mainPurple5
+                self.layer.borderColor = UIColor.mainPurple2.cgColor
+                self.layer.borderWidth = 3
+            }else{
+                self.backgroundColor = UIColor.mainPurple6
+                self.layer.borderColor = UIColor.clear.cgColor
+                self.layer.borderWidth = 0
+            }
+        }
+    }
+    
+    //StoryBoard를 사용했을 때 Nib을 활용하여 Cell 구성
+    override func awakeFromNib() {
+        super.awakeFromNib()
+    }
+    
+    required init(coder aDecoder: NSCoder){
+        fatalError("init(coder: ) has not been implemented")
+    }
+    
+    func setConstraints(){
+        NSLayoutConstraint.activate([
+            label.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
+        ])
+    }
+    
+    public func configue(_ sectionLabel: String){
+        self.backgroundColor = UIColor.mainPurple6
+        self.layer.cornerRadius = 8
+        self.layer.masksToBounds = true
+        self.label.text = sectionLabel
+    }
+}

--- a/Spacer/Spacer/Views/VisualTagView/Map/VisualTagMapViewController.swift
+++ b/Spacer/Spacer/Views/VisualTagView/Map/VisualTagMapViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class VisualTagMapViewController: UIViewController{
+class VisualTagMapViewController: UIViewController {
     
     lazy var headerTitle: UILabel = {
         let label = UILabel()
@@ -35,6 +35,12 @@ class VisualTagMapViewController: UIViewController{
         return button
     }()
     
+    lazy var testButton: UIButton = {
+        let button = NextButton()
+        button.setView(title: "테스트입니다.", titleColor: .white, backgroundColor: .black, target: VisualTagMapViewController(), action: #selector(test(_:)))
+        return button
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
@@ -58,22 +64,33 @@ class VisualTagMapViewController: UIViewController{
             headerTitle.widthAnchor.constraint(equalToConstant: view.bounds.width/10*9)
         ])
         
+        //backButton autolayout
         view.addSubview(backButton)
         backButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            backButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -30),
+            backButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -16),
             backButton.widthAnchor.constraint(equalTo: headerTitle.widthAnchor),
             backButton.centerXAnchor.constraint(equalTo: view.centerXAnchor)
         ])
         
         //next button autolayout
-        self.view.addSubview(self.nextButton)
+        view.addSubview(self.nextButton)
         nextButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             nextButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            nextButton.bottomAnchor.constraint(equalTo: backButton.topAnchor, constant: -20),
+            nextButton.bottomAnchor.constraint(equalTo: backButton.topAnchor, constant: -8),
             nextButton.widthAnchor.constraint(equalToConstant: view.bounds.width/10 * 9),
             nextButton.heightAnchor.constraint(equalToConstant: view.bounds.height/17)
+        ])
+        
+        //test button autolayout
+        view.addSubview(self.testButton)
+        testButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            testButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            testButton.bottomAnchor.constraint(equalTo: nextButton.topAnchor, constant: -16),
+            testButton.widthAnchor.constraint(equalToConstant: view.bounds.width/10 * 9),
+            testButton.heightAnchor.constraint(equalToConstant: view.bounds.height/9.59)
         ])
     }
     
@@ -93,4 +110,16 @@ class VisualTagMapViewController: UIViewController{
             }
         }
     }
+    @objc func test(_ sender: Any){
+        if let button = sender as? UIButton {
+            switch button.tag {
+            case 1:
+                print("test")
+            default:
+                print("Error")
+            }
+        }
+    }
 }
+
+

--- a/Spacer/Spacer/Views/VisualTagView/Map/VisualTagMapViewController.swift
+++ b/Spacer/Spacer/Views/VisualTagView/Map/VisualTagMapViewController.swift
@@ -97,6 +97,7 @@ class VisualTagMapViewController: UIViewController {
             nextButton.heightAnchor.constraint(equalToConstant: view.bounds.height/17)
         ])
         
+        //collectionview autolayout
         view.addSubview(self.mapCollectionView)
         mapCollectionView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([

--- a/Spacer/Spacer/Views/VisualTagView/PeopleRange/VisualTagPeopleRangeViewController.swift
+++ b/Spacer/Spacer/Views/VisualTagView/PeopleRange/VisualTagPeopleRangeViewController.swift
@@ -7,8 +7,13 @@
 
 import UIKit
 
-class VisualTagPeopleRangeViewController: UIViewController {
+let ranges = ["20명 이하", "20~40명", "40~60명","60~80명","80명 이상","상관없음"]
+var rangeItemArray: [Bool] = Array<Bool>(repeating: false, count: ranges.count)
 
+class VisualTagPeopleRangeViewController: UIViewController {
+    //insets size for collection View
+    let sectionInsets = UIEdgeInsets(top: 10, left: 16, bottom: 10, right: 16)
+    
     lazy var headerTitle: UILabel = {
         let label = UILabel()
         label.textColor = UIColor(red: 25/255, green: 0, blue: 80/255, alpha: 1)
@@ -34,6 +39,20 @@ class VisualTagPeopleRangeViewController: UIViewController {
         let button = BackButton()
         button.setView(title: "이전으로 돌아가기", titleColor: UIColor(red: 119/255, green: 89/255, blue: 240/255, alpha: 1), target: VisualTagPeopleRangeViewController(), action: #selector(buttonAction(_:)))
         return button
+    }()
+    
+    lazy var peopleRangeCollectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.minimumLineSpacing = 8
+        layout.minimumInteritemSpacing = 8
+        layout.estimatedItemSize = .zero
+        
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.register(GridCollectionViewCell.self, forCellWithReuseIdentifier: GridCollectionViewCell.identifier)
+        collectionView.delegate = self
+        collectionView.dataSource = self
+        collectionView.allowsMultipleSelection = true
+        return collectionView
     }()
     
     override func viewDidLoad() {
@@ -76,6 +95,16 @@ class VisualTagPeopleRangeViewController: UIViewController {
             nextButton.widthAnchor.constraint(equalToConstant: view.bounds.width/10 * 9),
             nextButton.heightAnchor.constraint(equalToConstant: view.bounds.height/17)
         ])
+        
+        //collectionview autolayout
+        view.addSubview(self.peopleRangeCollectionView)
+        peopleRangeCollectionView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            peopleRangeCollectionView.bottomAnchor.constraint(equalTo: nextButton.topAnchor, constant: -32),
+            peopleRangeCollectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            peopleRangeCollectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            peopleRangeCollectionView.heightAnchor.constraint(equalToConstant: 200)
+        ])
     }
     
     //handling action for next, cancel button
@@ -93,6 +122,74 @@ class VisualTagPeopleRangeViewController: UIViewController {
             default:
                 print("Error")
             }
+        }
+    }
+}
+
+
+extension VisualTagPeopleRangeViewController: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout{
+    //collectionViewLayout sectionInsets configuration
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        return sectionInsets
+    }
+    
+    //size of cell
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let cellWidth: CGFloat = 114
+        let cellHeight: CGFloat =  88
+        return CGSize(width: cellWidth, height: cellHeight)
+    }
+    
+    //return number of cell
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return ranges.count
+    }
+    
+    //cell configuration
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: GridCollectionViewCell.identifier, for: indexPath) as! GridCollectionViewCell
+        cell.configue(ranges[indexPath.item])
+        return cell
+    }
+    
+    //cell selection handling delegate
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        //상관없음 버튼을 눌렀을 때
+        if indexPath.item == 5 {
+            for visibleCell in collectionView.indexPathsForVisibleItems{
+                collectionView.selectItem(at: visibleCell, animated: false, scrollPosition: [])
+                rangeItemArray[visibleCell.item] = true
+            }
+        }else{
+            collectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])
+            rangeItemArray[indexPath.item] = true
+        }
+        
+        //상관없음 버튼을 제외한 나머지 버튼들이 활성화가 되어 있다면 전국 버튼 활성화
+        let selection: [Bool] = Array(rangeItemArray[..<5])
+        if(selection.contains(false)) {return}
+        else{
+            collectionView.selectItem(at: [0,5], animated: false, scrollPosition: [])
+            rangeItemArray[5] = true
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+        if indexPath.item == 5{
+            for visibleCell in collectionView.indexPathsForVisibleItems{
+                collectionView.deselectItem(at: visibleCell, animated: false)
+                rangeItemArray[visibleCell.item] = false
+            }
+        }
+        else if indexPath.item != 5 && rangeItemArray[5] == true{
+            collectionView.deselectItem(at: [0,5], animated: false)
+            collectionView.deselectItem(at: indexPath, animated: false)
+            rangeItemArray[indexPath.item] = false
+            rangeItemArray[5] = false
+        }
+        else{
+            collectionView.deselectItem(at: indexPath, animated: false)
+            rangeItemArray[indexPath.item] = false
         }
     }
 }

--- a/Spacer/Spacer/Views/VisualTagView/PeopleRange/VisualTagPeopleRangeViewController.swift
+++ b/Spacer/Spacer/Views/VisualTagView/PeopleRange/VisualTagPeopleRangeViewController.swift
@@ -55,14 +55,14 @@ class VisualTagPeopleRangeViewController: UIViewController {
         headerTitle.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             headerTitle.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: (view.bounds.width/10)/2),
-            headerTitle.topAnchor.constraint(equalTo: cancelButton.bottomAnchor, constant: 7),
+            headerTitle.topAnchor.constraint(equalTo: cancelButton.bottomAnchor, constant: 8),
             headerTitle.widthAnchor.constraint(equalToConstant: view.bounds.width/10*9)
         ])
         
         view.addSubview(backButton)
         backButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            backButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -30),
+            backButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -16),
             backButton.widthAnchor.constraint(equalTo: headerTitle.widthAnchor),
             backButton.centerXAnchor.constraint(equalTo: view.centerXAnchor)
         ])
@@ -72,7 +72,7 @@ class VisualTagPeopleRangeViewController: UIViewController {
         nextButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             nextButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            nextButton.bottomAnchor.constraint(equalTo: backButton.topAnchor, constant: -20),
+            nextButton.bottomAnchor.constraint(equalTo: backButton.topAnchor, constant: -8),
             nextButton.widthAnchor.constraint(equalToConstant: view.bounds.width/10 * 9),
             nextButton.heightAnchor.constraint(equalToConstant: view.bounds.height/17)
         ])

--- a/Spacer/Spacer/Views/VisualTagView/PeopleTarget/VisualTagPeopleTargetViewController.swift
+++ b/Spacer/Spacer/Views/VisualTagView/PeopleTarget/VisualTagPeopleTargetViewController.swift
@@ -54,14 +54,14 @@ class VisualTagPeopleTargetViewController: UIViewController {
         headerTitle.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             headerTitle.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: (view.bounds.width/10)/2),
-            headerTitle.topAnchor.constraint(equalTo: cancelButton.bottomAnchor, constant: 7),
+            headerTitle.topAnchor.constraint(equalTo: cancelButton.bottomAnchor, constant: 8),
             headerTitle.widthAnchor.constraint(equalToConstant: view.bounds.width/10*9)
         ])
         
         view.addSubview(backButton)
         backButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            backButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -30),
+            backButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -16),
             backButton.widthAnchor.constraint(equalTo: headerTitle.widthAnchor),
             backButton.centerXAnchor.constraint(equalTo: view.centerXAnchor)
         ])
@@ -71,7 +71,7 @@ class VisualTagPeopleTargetViewController: UIViewController {
         nextButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             nextButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            nextButton.bottomAnchor.constraint(equalTo: backButton.topAnchor, constant: -20),
+            nextButton.bottomAnchor.constraint(equalTo: backButton.topAnchor, constant: -8),
             nextButton.widthAnchor.constraint(equalToConstant: view.bounds.width/10 * 9),
             nextButton.heightAnchor.constraint(equalToConstant: view.bounds.height/17)
         ])
@@ -82,6 +82,7 @@ class VisualTagPeopleTargetViewController: UIViewController {
         if let button = sender as? UIButton{
             switch button.tag {
             case 1:
+                
                 self.navigationController?.pushViewController(VisualTagPeopleRangeViewController(), animated: true)
             case 2:
                 super.dismiss(animated: true, completion: nil)

--- a/Spacer/Spacer/Views/VisualTagView/PeopleTarget/VisualTagPeopleTargetViewController.swift
+++ b/Spacer/Spacer/Views/VisualTagView/PeopleTarget/VisualTagPeopleTargetViewController.swift
@@ -152,7 +152,7 @@ extension VisualTagPeopleTargetViewController: UICollectionViewDataSource, UICol
     
     //cell selection handling delegate
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        //전국 버튼을 눌렀을 때
+        //상관없음 버튼을 눌렀을 때
         collectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])
         targetItemArray[indexPath.item] = true
     }

--- a/Spacer/Spacer/Views/VisualTagView/PeopleTarget/VisualTagPeopleTargetViewController.swift
+++ b/Spacer/Spacer/Views/VisualTagView/PeopleTarget/VisualTagPeopleTargetViewController.swift
@@ -7,8 +7,12 @@
 
 import UIKit
 
-class VisualTagPeopleTargetViewController: UIViewController {
+let targets = ["아이돌", "배우", "가수", "뮤지컬 배우", "운동선수", "캐릭터", "인플루언서", "래퍼", "성우", "코미디언", "해외 연예인", "기타"]
+var targetItemArray: [Bool] = Array<Bool>(repeating: false, count: targets.count)
 
+class VisualTagPeopleTargetViewController: UIViewController {
+    let sectionInsets = UIEdgeInsets(top: 10, left: 16, bottom: 10, right: 16)
+    
     lazy var headerTitle: UILabel = {
         let label = UILabel()
         label.textColor = UIColor(red: 25/255, green: 0, blue: 80/255, alpha: 1)
@@ -33,6 +37,20 @@ class VisualTagPeopleTargetViewController: UIViewController {
         let button = BackButton()
         button.setView(title: "이전으로 돌아가기", titleColor: UIColor(red: 119/255, green: 89/255, blue: 240/255, alpha: 1), target: VisualTagPeopleTargetViewController(), action: #selector(buttonAction(_:)))
         return button
+    }()
+    
+    lazy var peopleTargetCollectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.minimumLineSpacing = 8
+        layout.minimumInteritemSpacing = 8
+        layout.estimatedItemSize = .zero
+        
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.register(GridCollectionViewCell.self, forCellWithReuseIdentifier: GridCollectionViewCell.identifier)
+        collectionView.delegate = self
+        collectionView.dataSource = self
+        collectionView.allowsMultipleSelection = true
+        return collectionView
     }()
     
     override func viewDidLoad() {
@@ -75,6 +93,16 @@ class VisualTagPeopleTargetViewController: UIViewController {
             nextButton.widthAnchor.constraint(equalToConstant: view.bounds.width/10 * 9),
             nextButton.heightAnchor.constraint(equalToConstant: view.bounds.height/17)
         ])
+        
+        //collectionview autolayout
+        view.addSubview(self.peopleTargetCollectionView)
+        peopleTargetCollectionView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            peopleTargetCollectionView.topAnchor.constraint(equalTo: headerTitle.bottomAnchor, constant: 32),
+            peopleTargetCollectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            peopleTargetCollectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            peopleTargetCollectionView.heightAnchor.constraint(equalToConstant: 500)
+        ])
     }
     
     //handling action for next, cancel button
@@ -93,5 +121,44 @@ class VisualTagPeopleTargetViewController: UIViewController {
                 print("Error")
             }
         }
+    }
+}
+
+
+extension VisualTagPeopleTargetViewController: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout{
+    //collectionViewLayout sectionInsets configuration
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        return sectionInsets
+    }
+    
+    //size of cell
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let cellWidth: CGFloat = 114
+        let cellHeight: CGFloat =  88
+        return CGSize(width: cellWidth, height: cellHeight)
+    }
+    
+    //return number of cell
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return targets.count
+    }
+    
+    //cell configuration
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: GridCollectionViewCell.identifier, for: indexPath) as! GridCollectionViewCell
+        cell.configue(targets[indexPath.item])
+        return cell
+    }
+    
+    //cell selection handling delegate
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        //전국 버튼을 눌렀을 때
+        collectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])
+        targetItemArray[indexPath.item] = true
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+            collectionView.deselectItem(at: indexPath, animated: false)
+            targetItemArray[indexPath.item] = false
     }
 }


### PR DESCRIPTION
## 세부 사항
- 지도 선택 뷰, 타켓층 선택 뷰, 인원 선택 뷰에 들어가는 collectionView를 그렸습니다.
- 세 뷰에 들어가는 cell의 결이 비슷하여 이를 재활용할 수 있는 GridViewControllerCell을 구성하였습니다.

https://user-images.githubusercontent.com/35408352/197446153-1fc511eb-0b96-408e-82c0-5bd0f2a13fb4.mp4


## 특이사항
- 입력된 데이터들을 파라미터로써 다른 뷰에 넘겨줘야하는 기능은 아직 구현중에 있습니다.

## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)

- [X] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [X] 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [X] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [X] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 
대하여 알고 있습니다.

