### PR TITLE
[FEAT]/#70 BirthdayCafeView에서 최근 카페 후기 부분 임시로 막음

### DIFF
--- a/Spacer/Spacer.xcodeproj/project.pbxproj
+++ b/Spacer/Spacer.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		BF5F8AC128FEC91300CF9E3A /* ResultCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5F8AC028FEC91300CF9E3A /* ResultCollectionViewCell.swift */; };
 		BF5F8AC728FECF5800CF9E3A /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5F8AC628FECF5800CF9E3A /* ColorExtension.swift */; };
 		BF682FC2291814FF00706D1D /* VisualTagCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF682FC1291814FF00706D1D /* VisualTagCategoryViewController.swift */; };
+		BF899DD22925CCA600579199 /* ReviewUnderConstructionTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF899DD12925CCA600579199 /* ReviewUnderConstructionTableViewCell.swift */; };
 		BFB9B11928FFDA460056626C /* GradientExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB9B11828FFDA460056626C /* GradientExtension.swift */; };
 		BFB9B11F29003F110056626C /* FontExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB9B11E29003F110056626C /* FontExtension.swift */; };
 		BFB9B1222900415E0056626C /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = BFB9B1212900415E0056626C /* Pretendard-SemiBold.otf */; };
@@ -66,6 +67,7 @@
 		BF5F8AC028FEC91300CF9E3A /* ResultCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultCollectionViewCell.swift; sourceTree = "<group>"; };
 		BF5F8AC628FECF5800CF9E3A /* ColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtension.swift; sourceTree = "<group>"; };
 		BF682FC1291814FF00706D1D /* VisualTagCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualTagCategoryViewController.swift; sourceTree = "<group>"; };
+		BF899DD12925CCA600579199 /* ReviewUnderConstructionTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewUnderConstructionTableViewCell.swift; sourceTree = "<group>"; };
 		BFB9B11828FFDA460056626C /* GradientExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientExtension.swift; sourceTree = "<group>"; };
 		BFB9B11E29003F110056626C /* FontExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontExtension.swift; sourceTree = "<group>"; };
 		BFB9B1212900415E0056626C /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
@@ -177,6 +179,7 @@
 				BF5F8AB828FE878F00CF9E3A /* RecentCafeTableViewCell.swift */,
 				BF5F8ABA28FE881400CF9E3A /* RecentCafeCollectionViewCell.swift */,
 				BFD1381A290274BD004E6726 /* BirthdayCafeTableViewSectionHeader.swift */,
+				BF899DD12925CCA600579199 /* ReviewUnderConstructionTableViewCell.swift */,
 			);
 			path = BirthdayCafeView;
 			sourceTree = "<group>";
@@ -441,6 +444,7 @@
 				BF5F8AB228FE74A400CF9E3A /* MockParser.swift in Sources */,
 				D4C95C5128F528CB00992600 /* MyPageViewController.swift in Sources */,
 				D4C95C5728F5437200992600 /* CafeDetailViewController.swift in Sources */,
+				BF899DD22925CCA600579199 /* ReviewUnderConstructionTableViewCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Spacer/Spacer/Cores/BirthdayCafeView/BirthdayCafeViewController.swift
+++ b/Spacer/Spacer/Cores/BirthdayCafeView/BirthdayCafeViewController.swift
@@ -312,9 +312,12 @@ extension BirthdayCafeViewController: UITableViewDelegate, UITableViewDataSource
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         // 셀 터치시 남아있는 회색 표시 없애기
         tableView.deselectRow(at: indexPath, animated: false)
-        let cafeDetailViewController = CafeDetailViewController()
-        cafeDetailViewController.tempCafeInfo = tempCafeArray[indexPath.row]
-        self.navigationController?.pushViewController(cafeDetailViewController, animated: true)
+        if indexPath.section == 1 {
+            let cafeDetailViewController = CafeDetailViewController()
+            cafeDetailViewController.tempCafeInfo = tempCafeArray[indexPath.row]
+            self.navigationController?.pushViewController(cafeDetailViewController, animated: true)
+        }
+       
     }
 }
 

--- a/Spacer/Spacer/Cores/BirthdayCafeView/BirthdayCafeViewController.swift
+++ b/Spacer/Spacer/Cores/BirthdayCafeView/BirthdayCafeViewController.swift
@@ -261,6 +261,7 @@ extension BirthdayCafeViewController: UITableViewDelegate, UITableViewDataSource
 //            guard let cell = tableView.dequeueReusableCell(withIdentifier: RecentCafeTableViewCell.identifier, for: indexPath) as? RecentCafeTableViewCell else { return UITableViewCell() }
             guard let cell = tableView.dequeueReusableCell(withIdentifier: ReviewUnderConstructionTableViewCell.identifier) as? ReviewUnderConstructionTableViewCell else { return UITableViewCell() }
             cell.backgroundColor = .systemBackground
+            cell.selectionStyle = .none
             
             //MARK: - 3. self( = BirthdayCafeViewController)를 cell의 delegate로 채택
 //            cell.cellSelectedDelegate = self

--- a/Spacer/Spacer/Cores/BirthdayCafeView/BirthdayCafeViewController.swift
+++ b/Spacer/Spacer/Cores/BirthdayCafeView/BirthdayCafeViewController.swift
@@ -79,7 +79,11 @@ class BirthdayCafeViewController: UIViewController {
     private let birthdayCafeTableView: UITableView = {
         let table = UITableView(frame: .zero, style: .grouped)
         table.register(PopularCafeTableViewCell.self, forCellReuseIdentifier: PopularCafeTableViewCell.identifier)
-        table.register(RecentCafeTableViewCell.self, forCellReuseIdentifier: RecentCafeTableViewCell.identifier)
+        
+        //MARK: - 리뷰가 완료 되기 전까지 RecentCafeTableViewCell가 아닌 ReviewUnderConstructionTableViewCell로 대체됨
+        
+//        table.register(RecentCafeTableViewCell.self, forCellReuseIdentifier: RecentCafeTableViewCell.identifier)
+        table.register(ReviewUnderConstructionTableViewCell.self, forCellReuseIdentifier: ReviewUnderConstructionTableViewCell.identifier)
         table.register(BirthdayCafeTableViewSectionHeader.self, forHeaderFooterViewReuseIdentifier: BirthdayCafeTableViewSectionHeader.identifier)
         table.backgroundColor = .white
         table.translatesAutoresizingMaskIntoConstraints = false
@@ -251,14 +255,17 @@ extension BirthdayCafeViewController: UITableViewDelegate, UITableViewDataSource
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         switch indexPath.section {
         case Sections.recentCafeReview.rawValue :
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: RecentCafeTableViewCell.identifier, for: indexPath) as? RecentCafeTableViewCell else { return UITableViewCell() }
             
+            //MARK: - 리뷰가 완료 되기 전까지 RecentCafeTableViewCell가 아닌 ReviewUnderConstructionTableViewCell로 대체됨
+            
+//            guard let cell = tableView.dequeueReusableCell(withIdentifier: RecentCafeTableViewCell.identifier, for: indexPath) as? RecentCafeTableViewCell else { return UITableViewCell() }
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: ReviewUnderConstructionTableViewCell.identifier) as? ReviewUnderConstructionTableViewCell else { return UITableViewCell() }
             cell.backgroundColor = .systemBackground
             
             //MARK: - 3. self( = BirthdayCafeViewController)를 cell의 delegate로 채택
-            cell.cellSelectedDelegate = self
+//            cell.cellSelectedDelegate = self
             
-            cell.configure(with: self.tempCafeArray)
+//            cell.configure(with: self.tempCafeArray)
             
             return cell
             

--- a/Spacer/Spacer/Cores/BirthdayCafeView/ReviewUnderConstructionTableViewCell.swift
+++ b/Spacer/Spacer/Cores/BirthdayCafeView/ReviewUnderConstructionTableViewCell.swift
@@ -1,0 +1,44 @@
+//
+//  ReviewUnderConstructionTableViewCell.swift
+//  Spacer
+//
+//  Created by 허다솔 on 2022/11/17.
+//
+
+import UIKit
+
+class ReviewUnderConstructionTableViewCell: UITableViewCell {
+    static let identifier = "ReviewUnderConstructionTableViewCell"
+    
+    private let mainLabel:UILabel = {
+        let label = UILabel(frame: .zero)
+        label.text = "준비 중이에요"
+        label.textAlignment = .center
+        label.textColor = .mainPurple2
+        label.font = .systemFont(for: .header1)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        contentView.backgroundColor = .mainPurple6
+        addSubview(mainLabel)
+        NSLayoutConstraint.activate([
+            mainLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            mainLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            mainLabel.widthAnchor.constraint(equalToConstant: bounds.width),
+            mainLabel.heightAnchor.constraint(equalToConstant: 50),
+        ])
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: .padding.betweenContentsPadding/2, left: .padding.homeMargin, bottom: .padding.betweenContentsPadding/2, right: .padding.homeMargin))
+        contentView.layer.cornerRadius = 12
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}


### PR DESCRIPTION
## 세부 사항
- BirthdayCafeView에서 최근 카페 후기 부분 셀을 '준비 중이에요' 셀로 임시로 대체하였습니다.
- 

|BirthdayCafeView|
|:---:|
|<img src="https://user-images.githubusercontent.com/73656470/202338678-2e2e6c36-36a9-470a-94c3-c8244194c563.png" width="340">|

## 특이 사항
- 기존의 RecentCafeTableViewCell에 해당하는 부분은 추후 업데이트 시 사용하기 위해 주석처리 되었습니다.
- RecentCafeTableViewCell, RecentCafeCollectionViewCell이 현재로는 사용되지 않는 파일이 맞지만 추후 업데이트 시 사용하기 위해 남겨두었습니다.

## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)

- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 
대하여 알고 있습니다.

