### PR TITLE
[Fix] #91 세로로 스크롤했을 때 현재 카페 이미지 번호가 1로 바뀌는 현상 수정

### DIFF
--- a/Spacer/Spacer/Views/CafeDetailView/CafeDetailViewController.swift
+++ b/Spacer/Spacer/Views/CafeDetailView/CafeDetailViewController.swift
@@ -18,6 +18,7 @@ class CafeDetailViewController: UIViewController {
     
     lazy var scrollView: UIScrollView = {
         let scrollView = UIScrollView()
+        scrollView.tag = 1
         scrollView.bounces = false
         scrollView.delegate = self
         scrollView.translatesAutoresizingMaskIntoConstraints = false
@@ -36,6 +37,7 @@ class CafeDetailViewController: UIViewController {
     lazy var imageScrollView: UIScrollView = {
         // ScrollView와 내부 Content Size 정의
         let scrollView = UIScrollView(frame: CGRect(x: 0, y: 0, width: view.bounds.width, height: view.bounds.width / 3 * 4))
+        scrollView.tag = 2
         
         // 스크롤 인디케이터 삭제
         scrollView.showsHorizontalScrollIndicator = false

--- a/Spacer/Spacer/Views/CafeDetailView/CafeDetailViewController.swift
+++ b/Spacer/Spacer/Views/CafeDetailView/CafeDetailViewController.swift
@@ -527,8 +527,9 @@ extension CafeDetailViewController: UIScrollViewDelegate {
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         // 이미지를 스크롤해서 넘기면 해당 이미지의 카테고리와 세부 사이즈 정보, 현재 이미지 번호로 업데이트
-        let currentImageNumber = Int(scrollView.contentOffset.x / scrollView.frame.maxX)
-        if fmod(scrollView.contentOffset.x, scrollView.frame.maxX) == 0 {
+        if fmod(scrollView.contentOffset.x, scrollView.frame.maxX) == 0 && scrollView.tag == 2 {
+            let currentImageNumber = Int(scrollView.contentOffset.x / scrollView.frame.maxX)
+            
             setImageDescriptionView(categoryName: categoryNames[currentImageNumber], tempImageNumber: currentImageNumber + 1, sizeDescription: sizeDescriptions[currentImageNumber])
         }
     }


### PR DESCRIPTION
## 세부 사항
- #91 에서 발생한 오류를 수정하였습니다.
- imageScrollView에서 스크롤이 되었을 때 동작해야하는 딜리게이트함수가 scrollView를 스크롤 시에도 동작하여 생겨 발생한 문제로, 각 스크롤뷰에 태그를 추가하고 동작 실행전에 태그를 확인하는 조건문을 추가하여 해결하였습니다.

## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)

- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 
대하여 알고 있습니다.

