### PR TITLE
[Fix]/#89 BirthdayCafeView의 오토레이아웃 디버그 해결, SimpleTagView 폰트 적용

### DIFF
--- a/Spacer/Spacer/Cores/BirthdayCafeView/BirthdayCafeViewController.swift
+++ b/Spacer/Spacer/Cores/BirthdayCafeView/BirthdayCafeViewController.swift
@@ -121,6 +121,7 @@ class BirthdayCafeViewController: UIViewController {
         navBar.addSubview(heartButton)
         
         headerView = MyHeaderView(frame: CGRect(x: 0, y: 0, width: view.bounds.width, height: view.bounds.width * 150 / 390))
+        birthdayCafeTableView.frame = CGRect(x: 0, y: 0, width: view.bounds.width, height: view.bounds.height)
         birthdayCafeTableView.tableHeaderView = headerView
         
         headerView?.headerButton.addTarget(self, action: #selector(goToVisualTagView), for: .touchUpInside)

--- a/Spacer/Spacer/Cores/BirthdayCafeView/BirthdayCafeViewController.swift
+++ b/Spacer/Spacer/Cores/BirthdayCafeView/BirthdayCafeViewController.swift
@@ -175,7 +175,7 @@ class BirthdayCafeViewController: UIViewController {
             birthdayCafeTableView.topAnchor.constraint(equalTo:navBar.bottomAnchor),
             birthdayCafeTableView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             birthdayCafeTableView.widthAnchor.constraint(equalToConstant: view.bounds.width),
-            birthdayCafeTableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+            birthdayCafeTableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ]
         
         NSLayoutConstraint.activate(navBarConstraints)

--- a/Spacer/Spacer/Views/SimpleTagView/SimpleTagCollectionViewCell.swift
+++ b/Spacer/Spacer/Views/SimpleTagView/SimpleTagCollectionViewCell.swift
@@ -12,7 +12,7 @@ class SimpleTagCollectionViewCell: UICollectionViewCell {
     
     var buttonTitle: UILabel = {
         let label = UILabel()
-        label.font = UIFont.systemFont(for: .header6)
+        label.font = UIFont.systemFont(for: .body1)
         label.textColor = .mainPurple3
         label.numberOfLines = 2
         label.textAlignment = .center

--- a/Spacer/Spacer/Views/SimpleTagView/SimpleTagViewController.swift
+++ b/Spacer/Spacer/Views/SimpleTagView/SimpleTagViewController.swift
@@ -209,6 +209,7 @@ class SimpleTagViewController: UIViewController {
     lazy var applyFilterButton: UIButton = {
         let button = UIButton(type: .custom)
         button.setTitle("필터 적용하기", for: .normal)
+        button.titleLabel?.font = .systemFont(for: .header6)
         button.setTitleColor(.grayscale7, for: .normal)
         button.backgroundColor = .mainPurple3
         button.layer.cornerRadius = 12


### PR DESCRIPTION
## 세부 사항
- SimpleTagView에 폰트 적용
- BirthdayCafeView의 TableView의 프레임을 설정하여 디버그창에서의 오토레이아웃 버그를 해결
- BirthdayCafeView의 birthdayCafeTableView의 오토레이아웃을 safeAreaLayoutGuides로 설정된 부분을 제거하여 뒤로 가기를 하였을 때 테이블뷰의 하단이 잘려보이는 부분을 해결

## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)

- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 
대하여 알고 있습니다.

