### PR TITLE
[Fix]/#100 내일 날짜를 기준으로 캘린더를 설정

### DIFF
--- a/Spacer/Spacer/Views/SimpleTagView/SimpleTagViewController.swift
+++ b/Spacer/Spacer/Views/SimpleTagView/SimpleTagViewController.swift
@@ -225,6 +225,9 @@ class SimpleTagViewController: UIViewController {
         setup()
         setAction()
         
+        // 하루 뒤의 날짜가 캘린더의 기준으로 보이도록 설정
+        myCalendar.setCurrentPage(Date().addingTimeInterval(TimeInterval(86400)), animated: true)
+        
         // SearchListView에서 선택되었던 날짜를 보임
         if let storedFirstDate = storedFirstDate, let storedLastDate = storedLastDate {
             firstDate = dateFormatConverter(storedFirstDate)

--- a/Spacer/Spacer/Views/SimpleTagView/SimpleTagViewController.swift
+++ b/Spacer/Spacer/Views/SimpleTagView/SimpleTagViewController.swift
@@ -605,10 +605,8 @@ extension SimpleTagViewController: FSCalendarDelegate, FSCalendarDataSource, FSC
     }
     
     private func configureVisibleCells() {
-        var count = 0
         //지금 보는 페이지의 cell 정리
         myCalendar.visibleCells().forEach{ (cell) in
-            count += 1
             let date = myCalendar.date(for: cell)
             let position = myCalendar.monthPosition(for: cell)
             self.configure(cell: cell, for: date!, at: position)

--- a/Spacer/Spacer/Views/VisualTagView/Calendar/VisualTagCalendarViewController.swift
+++ b/Spacer/Spacer/Views/VisualTagView/Calendar/VisualTagCalendarViewController.swift
@@ -208,7 +208,7 @@ class VisualTagCalendarViewController: UIViewController, FSCalendarDelegateAppea
 }
 
 //button method compilation
-extension VisualTagCalendarViewController{
+extension VisualTagCalendarViewController {
     //handling action for next, cancel button
     @objc func buttonAction(_ sender: Any) {
         if let button = sender as? UIButton {
@@ -256,7 +256,7 @@ extension VisualTagCalendarViewController{
     
     //set calendar label function using NSMutableAttributedString
     //For inserting text with Image
-    private func setCalendarLabel() -> NSMutableAttributedString{
+    private func setCalendarLabel() -> NSMutableAttributedString {
         let attributedString = NSMutableAttributedString(string: " ")
         let calendarImage = NSTextAttachment()
         calendarImage.image = UIImage(systemName: "calendar")?.withTintColor(.mainPurple2, renderingMode: .alwaysOriginal)
@@ -266,10 +266,10 @@ extension VisualTagCalendarViewController{
         if firstDate != nil {
             if lastDate != nil {
                 attributedString.append(NSAttributedString(string: " \(dateFormatConverter(firstDate!)) - \(dateFormatConverter(lastDate!))"))
-            }else{
+            } else {
                 attributedString.append(NSAttributedString(string: " \(dateFormatConverter(firstDate!)) - 선택 안함"))
             }
-        }else{
+        } else {
             attributedString.append(NSAttributedString(string: " 선택 안함 - 선택 안함"))
         }
         return attributedString
@@ -278,7 +278,7 @@ extension VisualTagCalendarViewController{
 
 //FSCalendar Delegate
 extension VisualTagCalendarViewController: FSCalendarDelegate, FSCalendarDataSource {
-    func dateFormatConverter(_ date: Date) -> String{
+    func dateFormatConverter(_ date: Date) -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy. MM. dd"
         dateFormatter.locale = Locale(identifier: "ko_KR")
@@ -305,14 +305,14 @@ extension VisualTagCalendarViewController: FSCalendarDelegate, FSCalendarDataSou
         }
     }
     
-    func datesRange(from: Date, to: Date) -> [Date]{
-        if from > to{
+    func datesRange(from: Date, to: Date) -> [Date] {
+        if from > to {
             return [Date]()
         }
         var tempDate = from
         var array = [tempDate]
         
-        while tempDate < to{
+        while tempDate < to {
             tempDate = Calendar.current.date(byAdding: .day, value: 1, to: tempDate)!
             array.append(tempDate)
         }
@@ -324,6 +324,7 @@ extension VisualTagCalendarViewController: FSCalendarDelegate, FSCalendarDataSou
         let cell = calendar.dequeueReusableCell(withIdentifier: CustomCalenderCell.identifier, for: date, at: position)
         return cell
     }
+    
     func calendar(_ calendar: FSCalendar, willDisplay cell: FSCalendarCell, for date: Date, at monthPosition: FSCalendarMonthPosition) {
         self.configure(cell: cell, for: date, at: monthPosition)
     }
@@ -336,29 +337,29 @@ extension VisualTagCalendarViewController: FSCalendarDelegate, FSCalendarDataSou
         return monthPosition == .current
     }
     
-    func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition){
+    func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
         //return 되기전에 무조건적으로 실행해야하는 코드 viewWillAppear -> AppearanceTransition
-        defer{
+        defer {
             configureVisibleCells()
             beginAppearanceTransition(true, animated: true)
             endAppearanceTransition()
         }
         
         // 오늘 이전의 날짜를 선택했을 경우 초기화
-        if date < Date(){
+        if date < Date() {
             calendar.deselect(date)
-            if firstDate != nil{
+            if firstDate != nil {
                 calendar.deselect(firstDate!)
             }
-            if lastDate != nil{
+            if lastDate != nil {
                 calendar.deselect(lastDate!)
             }
-            
-            if datesRange != nil{
+            if datesRange != nil {
                 for d in self.datesRange!{
                     calendar.deselect(d)
                 }
             }
+            
             firstDate = nil
             lastDate = nil
             datesRange = []
@@ -375,10 +376,11 @@ extension VisualTagCalendarViewController: FSCalendarDelegate, FSCalendarDataSou
             datesRange = [firstDate!]
             return
         }
+        
         // 처음 선택한 값은 있고 2번째를 선택했을 경우
         if firstDate != nil && lastDate == nil {
             // 만일 2번째 선택한 값이 첫번째 값보다 적다면... 2번째 선택한 값을 firstDate로 바꿔버림
-            if date <= firstDate!{
+            if date <= firstDate! {
                 calendar.deselect(firstDate!)
                 firstDate = date
                 datesRange = [firstDate!]
@@ -401,7 +403,7 @@ extension VisualTagCalendarViewController: FSCalendarDelegate, FSCalendarDataSou
         
         // 둘 다 값이 있을 경우에 선택했을 경우 다시 초기화
         if firstDate != nil && lastDate != nil {
-            for d in calendar.selectedDates{
+            for d in calendar.selectedDates {
                 calendar.deselect(d)
             }
             lastDate = nil
@@ -443,8 +445,8 @@ extension VisualTagCalendarViewController: FSCalendarDelegate, FSCalendarDataSou
     private func configureVisibleCells() {
         var count = 0
         //지금 보는 페이지의 cell 정리
-        calendar.visibleCells().forEach{ (cell) in
             count += 1
+        calendar.visibleCells().forEach { (cell) in
             let date = calendar.date(for: cell)
             let position = calendar.monthPosition(for: cell)
             self.configure(cell: cell, for: date!, at: position)
@@ -455,7 +457,7 @@ extension VisualTagCalendarViewController: FSCalendarDelegate, FSCalendarDataSou
         let customCell = (cell as! CustomCalenderCell)
         var selectionType = SelectionType.none
         if position == .current {
-            if calendar.selectedDates.contains(date){
+            if calendar.selectedDates.contains(date) {
                 let previousDate = self.calendar.gregorian.date(byAdding: .day, value: -1, to: date)!
                 let nextDate = self.calendar.gregorian.date(byAdding: .day, value: 1, to: date)!
                 

--- a/Spacer/Spacer/Views/VisualTagView/Calendar/VisualTagCalendarViewController.swift
+++ b/Spacer/Spacer/Views/VisualTagView/Calendar/VisualTagCalendarViewController.swift
@@ -443,9 +443,7 @@ extension VisualTagCalendarViewController: FSCalendarDelegate, FSCalendarDataSou
     }
     
     private func configureVisibleCells() {
-        var count = 0
         //지금 보는 페이지의 cell 정리
-            count += 1
         calendar.visibleCells().forEach { (cell) in
             let date = calendar.date(for: cell)
             let position = calendar.monthPosition(for: cell)

--- a/Spacer/Spacer/Views/VisualTagView/Calendar/VisualTagCalendarViewController.swift
+++ b/Spacer/Spacer/Views/VisualTagView/Calendar/VisualTagCalendarViewController.swift
@@ -112,6 +112,8 @@ class VisualTagCalendarViewController: UIViewController, FSCalendarDelegateAppea
         view.backgroundColor = .systemBackground
         
         setup()
+        // 하루 뒤의 날짜가 캘린더의 기준으로 보이도록 설정
+        myCalendar.setCurrentPage(Date().addingTimeInterval(TimeInterval(86400)), animated: true)
     }
     
     override func didReceiveMemoryWarning() {


### PR DESCRIPTION
## 세부 사항
- 내일 날짜를 기준으로 캘린더를 설정함으로 매월 말 일에 캘린더의 첫 페이지가 비활성화 되어 직접 다음달로 옮겨야하는 문제를 해결함
- VisualTagCalendarView에서 사용하지 않은 코드삭제와 공백을 style에 맞게 수정하였습니다.

## 특이사항
- `myCalendar.setCurrentPage(Date().addingTimeInterval(TimeInterval(86400)), animated: true)` 해당 날짜 기준으로 86400초 = 1일 후를 기준으로 달력의 현재페이지를 설정하는 코드입니다.
이 부분의 동작 여부를 중점으로 확인하여 주세요!

## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)

- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 
대하여 알고 있습니다.

