### PR TITLE
[Fix] #96 상세정보 뷰에서 pageController 스와이프를 이용한 세그먼트 이동 막기

### DIFF
--- a/Spacer/Spacer/Views/CafeDetailView/CafeDetailViewController.swift
+++ b/Spacer/Spacer/Views/CafeDetailView/CafeDetailViewController.swift
@@ -131,8 +131,6 @@ class CafeDetailViewController: UIViewController {
     lazy var pageController: UIPageViewController = {
         let pageController = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal)
         pageController.setViewControllers([dataViewControllers[0]], direction: .forward, animated: true)
-        pageController.dataSource = self
-        pageController.delegate = self
         pageController.view.translatesAutoresizingMaskIntoConstraints = false
         return pageController
     }()
@@ -564,30 +562,3 @@ extension CafeDetailViewController: UIScrollViewDelegate {
     }
 }
 
-extension CafeDetailViewController: UIPageViewControllerDelegate, UIPageViewControllerDataSource {
-    
-    // pageViewController를 오른쪽에서 왼쪽으로 스크롤 할 때 ViewController 변경
-    func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
-        guard let index = dataViewControllers.firstIndex(of: viewController), index - 1 >= 0 else {
-            return nil
-        }
-        return dataViewControllers[index - 1]
-    }
-    
-    // pageViewController를 왼쪽에서 오른쪽으로 스크롤 할 때 ViewController 변경
-    func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
-        guard let index = dataViewControllers.firstIndex(of: viewController), index + 1 < dataViewControllers.count else {
-            return nil
-        }
-        return dataViewControllers[index + 1]
-    }
-    
-    // pageViewController 애니메이션이 끝났을 때 segmentdControl의 selectedIndex 변경
-    func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
-        guard let viewController = pageViewController.viewControllers?[0], let index = dataViewControllers.firstIndex(of: viewController) else {
-            return
-        }
-        segmentedControl.selectedSegmentIndex = index
-    }
-    
-}


### PR DESCRIPTION
## 세부 사항
- 기존에 pageController를 스와이프를 이용해 세그먼트를 이동했으나, #96 에 따라 이를 수정하였습니다.
- pageController의 datasource와 delegate를 삭제하여 자동 페이징 가능 문제를 해결하였습니다.

## 특이사항
- 새로운 코드 작성이나 기능 추가 없이 기존 코드만 삭제하여 해결하였습니다.

## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)

- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 
대하여 알고 있습니다.

