### PR TITLE
[Feat] #102 update cafe's number of favorites

### DIFF
--- a/Spacer/Spacer/Managers/APICaller.swift
+++ b/Spacer/Spacer/Managers/APICaller.swift
@@ -29,4 +29,15 @@ class APICaller {
         return output
     }
     
+    static func requestPutData<T: Codable>(url: String, dataType: T.Type) async throws -> T  {
+        let url = URL(string: baseURL + url)
+        var request = URLRequest(url: url!)
+        request.httpMethod = "PUT"
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard (response as? HTTPURLResponse)?.statusCode == 200 else { throw APIError.HTTPError }
+        guard let output = try? JSONDecoder().decode(dataType, from: data) else { throw APIError.DataParsingError }
+        
+        return output
+    }
 }

--- a/Spacer/Spacer/Views/CafeDetailView/CafeDetailViewController.swift
+++ b/Spacer/Spacer/Views/CafeDetailView/CafeDetailViewController.swift
@@ -194,16 +194,12 @@ class CafeDetailViewController: UIViewController {
     private var categoryNames = [String]()
     private var sizeDescriptions = [String]()
     private var isFavoriteButtonOn = false
-    private let navigationAppearance = UINavigationBarAppearance()
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
         // navigationBar & tabBar 설정
-        navigationAppearance.configureWithTransparentBackground()
-        navigationController?.isNavigationBarHidden = false
-        navigationController?.navigationBar.standardAppearance = navigationAppearance
-        navigationController?.navigationBar.tintColor = .mainPurple1
+        setNavigationBar()
         tabBarController?.tabBar.isHidden = true
     }
     
@@ -344,6 +340,22 @@ class CafeDetailViewController: UIViewController {
                 numberOfFavorties.text = String(newCafeNumberOfFavorites)
             }
         }
+    }
+    
+    @objc private func touchedNavigationBackButton() {
+        self.navigationController?.popViewController(animated: true)
+    }
+    
+    private func setNavigationBar() {
+        let navigationAppearance = UINavigationBarAppearance()
+        navigationAppearance.configureWithTransparentBackground()
+        navigationController?.isNavigationBarHidden = false
+        navigationController?.navigationBar.standardAppearance = navigationAppearance
+        navigationController?.navigationBar.tintColor = .mainPurple1
+
+        let backIcon = UIBarButtonItem(image: UIImage(named: "BackButton"), style: .done, target: self, action: #selector(touchedNavigationBackButton))
+        navigationItem.leftBarButtonItem = backIcon
+        navigationItem.leftBarButtonItem?.tintColor = UIColor.mainPurple1
     }
     
     func setCafeImages(width: CGFloat) {


### PR DESCRIPTION
## 세부 사항
- CafeDetailView에서 찜버튼을 터치하면 이미지만 비활성화 됨이 아니라 서버에 요청해 좋아요수를 업데이트 하도록 코드를 추가하였습니다.
- APICaller에 HTTP PUT 요청을 위한 함수를 추가하였습니다.
- 네비게이션바의 뒤로가기 버튼이 뷰마다 다른 이슈를 해결하기 위해 CafeDetailView의 네비게이션바 뒤로가기 버튼을 커스텀으로 추가하였습니다.

## 특이사항
- 네비게이션바에 추가된 커스텀 뒤로가기 버튼에 연결된 액션함수에 #108 을 해결하기 위한 코드가 추가될 예정입니다.
- 현재 앱 내에 저장된 정보를 버튼이 터치될때만 서버에 업데이트 요청을 하므로, 시뮬레이터에서 찜버튼을 활성화/비활성화 하는 내용도 모두 서버에 반영이 되며 유저가 앱을 삭제할 시 저장된 데이터가 모두 날아가므로 좋아요된 카페를 서버에 요청해 수를 줄일 수 있는 방법이 존재하지 않습니다.
  - 이 문제점은 인지해놓고 있되, 이후 유저 로그인을 추가하고 유저 정보에 찜한 카페를 저장하는 방법으로 해결할 수 있을 것 같습니다.
  -  향후 이점을 해결하기 위한 논의가 필요합니다.

## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)

- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 
대하여 알고 있습니다.

